### PR TITLE
fix(pos_sumup): treat poll 404 as pending and prevent double charges

### DIFF
--- a/pos_sumup/__manifest__.py
+++ b/pos_sumup/__manifest__.py
@@ -2,7 +2,7 @@
 # Part of Odoo. See LICENSE file for full copyright and licensing details.
 {
     'name': 'POS Sumup',
-    'version': '1.0',
+    'version': '1.1',
     'category': 'Sales/Point of Sale',
     'sequence': 6,
     'summary': 'Integrate your POS with a SumUp payment terminal',

--- a/pos_sumup/models/pairing_wizard.py
+++ b/pos_sumup/models/pairing_wizard.py
@@ -42,9 +42,34 @@ class SumUpReaderPairingWizard(models.TransientModel):
             "name": self.reader_name,
             "meta": {}
         }
-        response = requests.post(url, headers=headers, data=json.dumps(payload), timeout=10)
+        try:
+            response = requests.post(url, headers=headers, data=json.dumps(payload), timeout=10)
+        except requests.exceptions.RequestException as e:
+            raise UserError(_("Could not reach SumUp: %s", e))
+
         if response.status_code != 201:
-            raise UserError(response.json()['message'])
+            # Surface the real SumUp error instead of crashing on a missing
+            # 'message' key (the error body shape varies: message / error_message
+            # / error_description / error, and is sometimes not JSON at all).
+            try:
+                body = response.json()
+            except ValueError:
+                body = {}
+            msg = (
+                body.get('message')
+                or body.get('error_message')
+                or body.get('error_description')
+                or body.get('error')
+                or (response.text or '').strip()
+                or _("Unknown error")
+            )
+            raise UserError(_(
+                "SumUp reader pairing failed (HTTP %(code)s): %(msg)s\n\n"
+                "Check that the Merchant Code and API Key on the SumUp provider are "
+                "correct and enabled, and that the pairing code is still valid "
+                "(they expire quickly — generate a fresh one if needed).",
+                code=response.status_code, msg=msg,
+            ))
 
         data = response.json()
         self.env['sumup.terminal'].create({

--- a/pos_sumup/models/payment_provider.py
+++ b/pos_sumup/models/payment_provider.py
@@ -43,20 +43,49 @@ class PaymentProvider(models.Model):
             _logger.error("SumUp Connection Error")
             return {'error': {'code': 'NETWORK_ERROR', 'message': 'Could not connect to SumUp.'}}
         except requests.exceptions.HTTPError as e:
-            _logger.error("SumUp API HTTP Error: %s", e)
-            if response.status_code in (401, 403):
-                 return {'error': {'code': 'AUTH_ERROR', 'message': 'Authentication failed. Check API Key.'}}
-            
-            # Try to get more details from the response body for 400/422
+            status_code = response.status_code
+            # A 404 is expected while polling for a transaction that SumUp has
+            # not indexed yet (the reader checkout is asynchronous). Do not spam
+            # the log with errors for it; callers decide how to treat it via the
+            # 'http_status' key below.
+            body_text = (response.text or '')[:1000]
+            if status_code == 404:
+                _logger.info("SumUp API 404 (resource not found / not yet available): %s", url)
+            else:
+                _logger.error("SumUp API HTTP Error %s for %s | body=%s", status_code, url, body_text)
+
+            if status_code in (401, 403):
+                 return {'error': {'code': 'AUTH_ERROR', 'message': 'Authentication failed. Check API Key.', 'http_status': status_code}}
+
+            # Surface the real SumUp validation detail (the body shape varies:
+            # dict with message/error_message/detail, or a list of field errors).
+            error_code = 'API_ERROR'
+            error_msg = None
             try:
                 error_data = response.json()
-                error_msg = error_data.get('message') or error_data.get('error_description') or str(e)
-                error_code = error_data.get('error_code', 'API_ERROR')
-                return {'error': {'code': error_code, 'message': f"SumUp: {error_msg}"}}
             except ValueError:
-                pass
-                
-            return {'error': {'code': 'API_ERROR', 'message': str(e)}}
+                error_data = None
+            if isinstance(error_data, dict):
+                error_code = error_data.get('error_code', error_code)
+                error_msg = (error_data.get('message') or error_data.get('error_message')
+                             or error_data.get('error_description') or error_data.get('detail'))
+                if not error_msg and error_data.get('errors'):
+                    error_msg = str(error_data['errors'])
+            elif isinstance(error_data, list) and error_data:
+                parts = []
+                for item in error_data:
+                    if isinstance(item, dict):
+                        parts.append('%s: %s' % (
+                            item.get('param', '?'),
+                            item.get('message') or item.get('error_message') or item,
+                        ))
+                    else:
+                        parts.append(str(item))
+                error_msg = '; '.join(parts)
+            if not error_msg:
+                error_msg = body_text or str(e)
+
+            return {'error': {'code': error_code, 'message': f"SumUp: {error_msg}", 'http_status': status_code}}
         except requests.exceptions.RequestException as e:
             _logger.error("SumUp API Error: %s", e)
             return {'error': {'code': 'UNKNOWN_ERROR', 'message': str(e)}}

--- a/pos_sumup/models/pos_payment_method.py
+++ b/pos_sumup/models/pos_payment_method.py
@@ -80,7 +80,23 @@ class PosPaymentMethod(models.Model):
             params = {
                 'client_transaction_id': client_transaction_id
             }
-            return provider.sumup_make_request(endpoint, method='GET', params=params)
+            response = provider.sumup_make_request(endpoint, method='GET', params=params)
+
+            # The reader checkout is asynchronous and SumUp needs some time to
+            # make the transaction queryable through this endpoint. Until then it
+            # replies with a 404. That is NOT a failure: the payment may still be
+            # in progress or may have just succeeded on the terminal. Report it
+            # as a transient PENDING so the front-end keeps polling instead of
+            # treating it as an error (which previously caused the endless
+            # spinner and, on cashier abort, double charges).
+            error = response.get('error') if isinstance(response, dict) else None
+            if error and error.get('http_status') == 404:
+                return {'status': 'PENDING'}
+            # Some SumUp response shapes wrap the result in "items"; normalize to
+            # a single transaction object so the front-end can read 'status'.
+            if isinstance(response, dict) and response.get('items'):
+                return response['items'][0]
+            return response
 
         elif operation == 'cancel':
              endpoint = f"v0.1/merchants/{provider.sumup_merchant_code}/readers/{self.reader.terminal_id}/terminate"

--- a/pos_sumup/static/src/app/sumup_payment.js
+++ b/pos_sumup/static/src/app/sumup_payment.js
@@ -20,11 +20,53 @@ export class PaymentSumup extends PaymentInterface {
 
     sendPaymentCancel(order, uuid) {
         super.sendPaymentCancel(order, uuid);
-        return this._call_sumup({}, 'cancel');
+        // The "did the payment already succeed?" final check happens in the
+        // PaymentScreen.deletePaymentLine override (that is where we can decide
+        // whether the line is kept). By the time we get here the decision to
+        // terminate has been made, so just terminate the reader checkout.
+        return this._call_sumup({}, "cancel");
+    }
+
+    /**
+     * Called from the PaymentScreen before a SumUp line is cancelled/removed.
+     * If the payment already succeeded on the terminal, book it (so the cashier
+     * is not tricked into a second, cash payment -> the double-charge bug) and
+     * return true so the screen keeps the line instead of terminating/removing.
+     */
+    async bookIfAlreadySuccessful(line) {
+        const client_transaction_id = line && line.transaction_id;
+        if (!client_transaction_id) {
+            return false;
+        }
+        const status = await this._call_sumup(
+            { client_transaction_id: client_transaction_id },
+            "poll_status"
+        ).catch(() => null);
+
+        if (status && !status.error && status.status === "SUCCESSFUL") {
+            await this._finalize_successful_payment(line, status);
+            this._show_error(
+                _t(
+                    "This SumUp payment was already completed on the terminal and has been booked. It was NOT cancelled."
+                ),
+                _t("Payment already completed")
+            );
+            return true;
+        }
+        return false;
     }
 
     pending_sumup_line() {
         return this.pos.getPendingPaymentLine("sumup");
+    }
+
+    // Returns the payment line for `uuid` only if it is still part of the
+    // current order (i.e. not removed by a concurrent cancel). Used by the poll
+    // loop so it never resolves a result onto a removed line, which would crash
+    // the core's handlePaymentResponse (reading payment_method_id of undefined).
+    _live_line(uuid) {
+        const order = this.pos.getOrder();
+        return order && order.payment_ids.find((paymentLine) => paymentLine.uuid === uuid);
     }
 
     _handle_odoo_connection_failure(data = {}) {
@@ -149,45 +191,60 @@ export class PaymentSumup extends PaymentInterface {
     }
 
     async _poll_for_status(uuid, client_transaction_id) {
-        var line = this.pending_sumup_line();
-        if (!line || line.uuid !== uuid) {
-            return Promise.resolve(); // Payment cancelled or changed
+        // Stop conditions that must be checked at every step, because the cashier
+        // can cancel (remove the line) or the cancel path can book it (set it
+        // "done") while we are mid-poll:
+        //  - line removed   -> return false (core sets the orphan to retry, no crash)
+        //  - line already done -> return true (keep it done, don't downgrade)
+        let line = this._live_line(uuid);
+        if (!line) {
+            return false;
+        }
+        if (line.payment_status === "done") {
+            return true;
         }
 
         // Poll every 3 seconds
         await new Promise(resolve => setTimeout(resolve, 3000));
 
+        line = this._live_line(uuid);
+        if (!line) {
+            return false;
+        }
+        if (line.payment_status === "done") {
+            return true;
+        }
+
         var data = { 'client_transaction_id': client_transaction_id };
         const response = await this._call_sumup(data, 'poll_status');
 
-        if (response.error) {
-            console.error("SumUp Poll Error", response.error);
+        // Re-check liveness after the network round-trip.
+        line = this._live_line(uuid);
+        if (!line) {
+            return false;
+        }
+        if (line.payment_status === "done") {
+            return true;
+        }
+
+        // A genuine transport error (Odoo unreachable) is already handled by
+        // _call_sumup -> _handle_odoo_connection_failure (it sets the line to
+        // "retry" and rejects), so we never reach this point in that case.
+        if (response && response.error) {
+            // SumUp-side error while the payment may still be live on the
+            // terminal. We must NOT abandon the line here: doing so is exactly
+            // what produced the double charges. Keep polling; the only
+            // deliberate exit is a definitive status or the cashier pressing X
+            // (which runs a final status check before terminating).
+            console.warn("SumUp poll: transient error, keep polling", response.error);
             return this._poll_for_status(uuid, client_transaction_id);
         }
 
-        var status = response.status;
+        const status = response && response.status;
 
         if (status === 'SUCCESSFUL') {
-            line.setPaymentStatus("done");
-            line.transaction_id = response.id || response.transaction_code;
-
-            // Card details for receipt
-            if (response.card) {
-                line.card_type = response.card.type;
-                line.cardholder_name = response.card.last_4_digits;
-            }
-
-            // Handle Tipping: if authorized amount > requested amount
-            if (response.amount && response.amount > line.amount) {
-                const tip_amount = response.amount - line.amount;
-                if (this.pos.config.tip_product_id) {
-                    await this.pos.setTip(tip_amount);
-                }
-                line.setAmount(response.amount);
-            }
-
-            return true;
-        } else if (status === 'FAILED') {
+            return this._finalize_successful_payment(line, response);
+        } else if (status === 'FAILED' || status === 'CANCELLED') {
             this._show_error(_t("Payment failed."));
             line.setPaymentStatus("retry");
             return false;
@@ -195,11 +252,41 @@ export class PaymentSumup extends PaymentInterface {
             this._show_error(_t("Payment expired."));
             line.setPaymentStatus("retry");
             return false;
-        } else if (status === 'PENDING') {
-            return this._poll_for_status(uuid, client_transaction_id);
-        } else {
-            this._show_error(_t("Payment expired."));
         }
+
+        // PENDING, our 404 -> PENDING mapping, or any other intermediate /
+        // unknown status: keep polling until SumUp returns a definitive result.
+        // Never give up on a transaction that might still succeed.
+        return this._poll_for_status(uuid, client_transaction_id);
+    }
+
+    async _finalize_successful_payment(line, response) {
+        // The poll loop and the cancel path can both observe SUCCESSFUL for the
+        // same transaction. Guard against booking it twice (which could e.g.
+        // apply the tip twice). setPaymentStatus("done") below runs before any
+        // await, so a second concurrent call sees "done" and bails out here.
+        if (line.payment_status === "done") {
+            return true;
+        }
+        line.setPaymentStatus("done");
+        line.transaction_id = response.id || response.transaction_code || line.transaction_id;
+
+        // Card details for receipt
+        if (response.card) {
+            line.card_type = response.card.type;
+            line.cardholder_name = response.card.last_4_digits;
+        }
+
+        // Handle Tipping: if authorized amount > requested amount
+        if (response.amount && response.amount > line.amount) {
+            const tip_amount = response.amount - line.amount;
+            if (this.pos.config.tip_product_id) {
+                await this.pos.setTip(tip_amount);
+            }
+            line.setAmount(response.amount);
+        }
+
+        return true;
     }
 
     _show_error(msg, title) {

--- a/pos_sumup/static/src/overrides/payment_screen/payment_screen.js
+++ b/pos_sumup/static/src/overrides/payment_screen/payment_screen.js
@@ -49,4 +49,39 @@ patch(PaymentScreen.prototype, {
 
         return await super.addNewPaymentLine(paymentMethod);
     },
+
+    async deletePaymentLine(uuid) {
+        const line = this.paymentLines.find((l) => l.uuid === uuid);
+
+        // Before cancelling/removing a SumUp payment that is still in progress,
+        // make sure it did not already succeed on the terminal. If it did, book
+        // it and KEEP the line (the core would otherwise remove it
+        // unconditionally), preventing the double charge. Only then fall back to
+        // the normal cancel (which terminates the reader and removes the line).
+        if (
+            line &&
+            line.payment_method_id?.use_payment_terminal === "sumup" &&
+            line.transaction_id &&
+            ["waiting", "waitingCard", "timeout"].includes(line.getPaymentStatus())
+        ) {
+            const terminal = line.payment_method_id.payment_terminal;
+            const booked = await terminal.bookIfAlreadySuccessful(line);
+            if (booked) {
+                this.numberBuffer.reset();
+                // Finish the order automatically if it is now fully paid, so the
+                // cashier is not left on a "stuck in payment" screen.
+                const order = this.currentOrder;
+                if (
+                    order.isPaid() &&
+                    this.pos.config.auto_validate_terminal_payment &&
+                    !order.isRefundInProcess()
+                ) {
+                    this.validateOrder(false);
+                }
+                return;
+            }
+        }
+
+        return super.deletePaymentLine(uuid);
+    },
 });

--- a/pos_sumup/tests/test_sumup_refund.py
+++ b/pos_sumup/tests/test_sumup_refund.py
@@ -32,11 +32,16 @@ class TestPosSumupRefund(TransactionCase):
             ('company_id', '=', cls.company.id),
             ('type', '=', 'bank'),
         ], limit=1)
+        cls.reader = cls.env['sumup.terminal'].create({
+            'name': 'Test Reader',
+            'terminal_id': 'rdr_test',
+        })
         cls.payment_method = cls.env['pos.payment.method'].create({
             'name': 'SumUp Terminal',
             'journal_id': journal.id,
             'payment_method_type': 'terminal',
             'use_payment_terminal': 'sumup',
+            'reader': cls.reader.id,
         })
 
     def test_sumup_full_refund_request(self):
@@ -86,6 +91,39 @@ class TestPosSumupRefund(TransactionCase):
 
         self.assertEqual(result['error']['code'], 'REFUND_LIMIT_EXCEEDED')
         self.assertEqual(mocked.call_count, 1)
+
+    def test_poll_status_maps_404_to_pending(self):
+        """A 404 while polling means the transaction is not indexed yet and must
+        be reported as PENDING so the front-end keeps polling instead of
+        treating it as a hard error."""
+        with patch.object(type(self.provider), 'sumup_make_request', return_value={
+            'error': {'code': 'API_ERROR', 'message': 'Not Found', 'http_status': 404},
+        }):
+            result = self.payment_method.proxy_sumup_request(
+                {'client_transaction_id': 'ctid-1'}, 'poll_status'
+            )
+
+        self.assertEqual(result, {'status': 'PENDING'})
+
+    def test_poll_status_passes_through_real_errors(self):
+        """Non-404 errors (e.g. auth) must not be hidden behind PENDING."""
+        error = {'error': {'code': 'AUTH_ERROR', 'message': 'nope', 'http_status': 401}}
+        with patch.object(type(self.provider), 'sumup_make_request', return_value=error):
+            result = self.payment_method.proxy_sumup_request(
+                {'client_transaction_id': 'ctid-2'}, 'poll_status'
+            )
+
+        self.assertEqual(result, error)
+
+    def test_poll_status_returns_successful_transaction(self):
+        """A resolved transaction is returned untouched to the front-end."""
+        transaction = {'id': 'txn-9', 'status': 'SUCCESSFUL', 'amount': 42.0}
+        with patch.object(type(self.provider), 'sumup_make_request', return_value=transaction):
+            result = self.payment_method.proxy_sumup_request(
+                {'client_transaction_id': 'ctid-3'}, 'poll_status'
+            )
+
+        self.assertEqual(result, transaction)
 
     def test_sumup_refund_falls_back_to_transaction_code_lookup(self):
         with patch.object(type(self.provider), 'sumup_make_request', side_effect=[


### PR DESCRIPTION
Reader checkout is asynchronous, so SumUp returns 404 for ~10-30s while the transaction is not yet indexed. The old code treated the 404 as an error and recursed forever -> endless spinner; when the cashier aborted, /terminate was sent (which cannot reverse a completed payment) -> the customer paid cash too -> double charge.

- backend: map poll 404 -> PENDING, expose http_status, surface the real SumUp error body (also fixes opaque 422/refund errors), log 404 as INFO
- frontend: poll never aborts on PENDING/unknown; robust against a removed/finished line (fixes handlePaymentResponse "undefined" crash)
- cancel: PaymentScreen.deletePaymentLine override does a final status check first; if the payment already succeeded it is booked and the line kept (no /terminate, no removal), order auto-validated when configured
- pairing wizard: surface the real SumUp error instead of KeyError
- tests: 3 new poll_status tests; version bump 1.0 -> 1.1

Known residual: cancelling exactly within the 404 window can still terminate; fully closed only by SumUp webhooks (follow-up).